### PR TITLE
cleaning up some of the markdown syntax, added $CID

### DIFF
--- a/wordpress_single_container/README.md
+++ b/wordpress_single_container/README.md
@@ -11,41 +11,38 @@ When you run the below commands, simply use sudo. This is a [known issue](https:
 
 This repo contains a recipe for making a [Docker](http://docker.io) container for Wordpress, using Linux, Apache and MySQL on Fedora. 
 To build, make sure you have Docker [installed](http://www.docker.io/gettingstarted/), clone this repo somewhere, and then run:
-
+```
 \# docker build -rm -t <yourname>/wordpress .
-
+```
 
 Or, alternately, build DIRECTLY from the github repo:
-
+```
 \# docker build -rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
-
+```
 
 Run it:
-
-\# docker run -d -p 80 -p 22 <yourname>/wordpress
-
-
+```
+\# CID=$(docker run -d -p 80 -p 22 <yourname>/wordpress)
+```
 
 Check docker logs after running to see MySQL root password and Wordpress MySQL password, as so:
-
-
-\# echo $(docker logs <container-id> | grep password)
-
+```
+\# echo $(docker logs $CID | grep password)
+```
 
 (note: you won't need the mysql root or the wordpress db password normally)
 
 Then find the external port assigned to your container:
-
-
-\# docker port <container-id> 80 
-
+```
+\# docker port $CID 80 
+```
 
 Visit in a webrowser, then fill out the form. No need to mess with wp-config.php, it's been auto-generated with proper values. 
 
 
 Note that this image now has a user account (appropriately named "user") and passwordless sudo for that user account. The password is generated upon startup; check logs for "ssh user password", docker ps for the port assigned to 22, and something like this to get in: 
-
-
+```
 \# ssh -p <port> user@localhost
+```
 
 


### PR DESCRIPTION
At first I thought the issue was some bugs in the help text, upon editing, I saw that it was just some issues with github markdown vs regular markdown. However, I also thought using $CID is a little easier for people.
