### PR TITLE
qpid: fix syntax errors in Dockerfile

### DIFF
--- a/qpid/Dockerfile
+++ b/qpid/Dockerfile
@@ -2,8 +2,7 @@ FROM fedora
 MAINTAINER William Henry <whenry@redhat.com>
 
 RUN yum -y update
-RUN yum install -y python-qpid qpid-cpp-server && yum clean 
-all
+RUN yum install -y python-qpid qpid-cpp-server && yum clean all
 
 ADD . /.qpidd
 
@@ -11,4 +10,4 @@ WORKDIR /.qpidd
 
 EXPOSE 5672
 
-ENTRYPOINT ["qpidd", "-t", "--auth=no"]`
+ENTRYPOINT ["qpidd", "-t", "--auth=no"]


### PR DESCRIPTION
This PR fixes some syntax errors in Apache Qpid Dockerfile
