### PR TITLE
'-rm' is deprecated, it will be replaced by '--rm' soon by Docker

### DIFF
--- a/Django/README.md
+++ b/Django/README.md
@@ -10,7 +10,7 @@ To build:
 Copy the sources down -
 
 
-\# docker build -rm -t <username>/django .
+\# docker build --rm -t <username>/django .
 
 
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -14,7 +14,7 @@ To build:
 Copy the sources down and do the build-
 
 ```
-# docker build -rm -t <username>/httpd .
+# docker build --rm -t <username>/httpd .
 ```
 
 To run (if port 80 is open on your host):

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -14,7 +14,7 @@ To build:
 Copy the sources down, then -
 
 ```
-# docker build -rm -t <username>/couchdb .
+# docker build --rm -t <username>/couchdb .
 ```
 
 To run:

--- a/firefox/README.md
+++ b/firefox/README.md
@@ -14,7 +14,7 @@ To build:
 Copy the sources down -
 
 ```
-# docker build -rm -t <username>/firefox .
+# docker build --rm -t <username>/firefox .
 ```
 
 To run:

--- a/hadoop/multi_container/namenode/README.md
+++ b/hadoop/multi_container/namenode/README.md
@@ -8,7 +8,7 @@ This was built and tested on a Fedora 20 host running Docker 0.9.0.
 1. To build:
 
 ```
-	# docker build -rm -t <username>/hadoop-namenode . |& tee hadoop_build.log
+	# docker build --rm -t <username>/hadoop-namenode . |& tee hadoop_build.log
 	# docker images
 ```
 

--- a/hadoop/multi_container/resourcemanager/README.md
+++ b/hadoop/multi_container/resourcemanager/README.md
@@ -8,7 +8,7 @@ This was built and tested on a Fedora 20 host running Docker 0.9.0.
 1. To build:
 
 ```
-# docker build -rm -t <username>/hadoop-resourcemgr . |& tee hadoop_build.log
+# docker build --rm -t <username>/hadoop-resourcemgr . |& tee hadoop_build.log
 # docker images
 ```
 

--- a/hadoop/single_container/README.md
+++ b/hadoop/single_container/README.md
@@ -5,7 +5,7 @@ Fedora dockerfile for Hadoop - Single container, multi-service.  No external vol
 
 1. To build:
 
-        # docker build -rm -t <username>/hadoop-single . |& tee hadoop_build.log
+        # docker build --rm -t <username>/hadoop-single . |& tee hadoop_build.log
 
         # docker images
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -11,7 +11,7 @@ Check your Docker version
 
 Perform the build
 
-    # docker build -rm -t <yourname>/mariadb .
+    # docker build --rm -t <yourname>/mariadb .
 
 Check the image out.
 

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -11,7 +11,7 @@ To build:
 
 Copy the sources down -
 
-    # docker build -rm -t <username>/memcached .
+    # docker build --rm -t <username>/memcached .
 
 To run:
 

--- a/mesos/master/README.md
+++ b/mesos/master/README.md
@@ -8,7 +8,7 @@ This was built and tested on a Fedora 20 host running Docker 0.9.0.
 1. To build:
 
 ```
-	# docker build -rm -t <username>/mesos-master .
+	# docker build --rm -t <username>/mesos-master .
 	# docker images
 ```
 

--- a/mesos/slave/README.md
+++ b/mesos/slave/README.md
@@ -8,7 +8,7 @@ This was built and tested on a Fedora 20 host running Docker 0.9.0.
 1. To build:
 
 ```
-	# docker build -rm -t <username>/mesos-slave .
+	# docker build --rm -t <username>/mesos-slave .
 	# docker images
 ```
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -11,7 +11,7 @@ To build:
 
 Copy the sources down -
 
-    # docker build -rm -t <username>/mongo .
+    # docker build --rm -t <username>/mongo .
 
 To run:
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -9,7 +9,7 @@ Check your Docker version
 
 Perform the build
 
-    # docker build -rm -t <yourname>/MySQL .
+    # docker build --rm -t <yourname>/MySQL .
 
 Check the image out.
 

--- a/needs_work/fedora-fas/README.md
+++ b/needs_work/fedora-fas/README.md
@@ -12,7 +12,7 @@ Installation
 
 Copy the sources and run the build process:
 
-    $ docker build -rm -t <username>/fas .
+    $ docker build --rm -t <username>/fas .
 
 Running
 ----

--- a/needs_work/hadoop/single_container/README.md
+++ b/needs_work/hadoop/single_container/README.md
@@ -7,7 +7,7 @@ This was built and tested on a Fedora 20 host running Docker 0.7.6.
 
 1. To build:
 
-\# docker build -rm -t <username>/hadoop-single . |& tee hadoop_build.log
+\# docker build --rm -t <username>/hadoop-single . |& tee hadoop_build.log
 
 \# docker images
 

--- a/needs_work/wordpress_linked_container/apache/README.md
+++ b/needs_work/wordpress_linked_container/apache/README.md
@@ -12,12 +12,12 @@ When you run the below commands, simply use sudo. This is a [known issue](https:
 This repo contains a recipe for making a [Docker](http://docker.io) container for Wordpress, using Linux, Apache and MySQL on Fedora. 
 To build, make sure you have Docker [installed](http://www.docker.io/gettingstarted/), clone this repo somewhere, and then run:
 
-# docker build -rm -t <yourname>/wordpress .
+# docker build --rm -t <yourname>/wordpress .
 
 
 Or, alternately, build DIRECTLY from the github repo:
 
-# docker build -rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
+# docker build --rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
 
 
 Run it:

--- a/needs_work/wordpress_linked_container/mysql/README.md
+++ b/needs_work/wordpress_linked_container/mysql/README.md
@@ -8,12 +8,12 @@ When you run the below commands, simply use sudo. This is a [known issue](https:
 This repo contains a recipe for making a [Docker](http://docker.io) container for Wordpress, using Linux, Apache and MySQL on Fedora. 
 To build, make sure you have Docker [installed](http://www.docker.io/gettingstarted/), clone this repo somewhere, and then run:
 
-\# docker build -rm -t <yourname>/wordpress .
+\# docker build --rm -t <yourname>/wordpress .
 
 
 Or, alternately, build DIRECTLY from the github repo:
 
-\# docker build -rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
+\# docker build --rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
 
 
 Run it:

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -7,7 +7,7 @@ To build:
 
 Copy the sources down -
 
-    # docker build -rm -t <username>/nginx .
+    # docker build --rm -t <username>/nginx .
 
 To run:
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -12,7 +12,7 @@ To build:
 
 Copy the sources down and do the build-
 
-    # docker build -rm -t <username>/nodejs .
+    # docker build --rm -t <username>/nodejs .
 
 To run (if port 8080 is open on your host):
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -7,7 +7,7 @@ Fedora dockerfile for PostgreSQL
 
 Copy the sources down and do the build-
 
-    # docker build -rm -t username/postgresql . |& tee postgres_build.log
+    # docker build --rm -t username/postgresql . |& tee postgres_build.log
 
 2.	To run 
 

--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,7 @@ To build:
 
 Copy the sources down and do the build-
 
-    # docker build -rm -t <username>/python .
+    # docker build --rm -t <username>/python .
 
 To run (if port 8080 is open on your host):
 

--- a/qpid/README.md
+++ b/qpid/README.md
@@ -10,7 +10,7 @@ Get Docker version
 
 To build:
 
-    # docker build -rm -t fedora-qpidd .
+    # docker build --rm -t fedora-qpidd .
 
 Launch the container using:
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -7,7 +7,7 @@ To build:
 
 Copy the sources down -
 
-	# docker build -rm -t <username>/rabbitmq .
+	# docker build --rm -t <username>/rabbitmq .
 
 To run:
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -7,7 +7,7 @@ To build:
 
 Copy the sources down -
 
-	# docker build -rm -t <username>/redis .
+	# docker build --rm -t <username>/redis .
 
 To run:
 

--- a/registry/README.md
+++ b/registry/README.md
@@ -9,7 +9,7 @@ Get the version of Docker:
 
 To build:
 
-	# docker build -rm -t <yourname>/registry .
+	# docker build --rm -t <yourname>/registry .
 
 To run:
 

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -4,7 +4,7 @@
 
 Copy the sources to your docker host and build the container:
 
-	# docker build -rm -t <username>/ssh .
+	# docker build --rm -t <username>/ssh .
 
 To run:
 

--- a/systemd/wordpress_single_container/README.md
+++ b/systemd/wordpress_single_container/README.md
@@ -13,13 +13,13 @@ This repo contains a recipe for making a [Docker](http://docker.io) container fo
 To build, make sure you have Docker [installed](http://www.docker.io/gettingstarted/), clone this repo somewhere, and then run:
 
 ```
-# docker build -rm -t <yourname>/wordpress .
+# docker build --rm -t <yourname>/wordpress .
 ```
 
 Or, alternately, build DIRECTLY from the github repo:
 
 ```
-# docker build -rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
+# docker build --rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
 ```
 
 Run it:

--- a/wordpress_single_container/README.md
+++ b/wordpress_single_container/README.md
@@ -13,13 +13,13 @@ This repo contains a recipe for making a [Docker](http://docker.io) container fo
 To build, make sure you have Docker [installed](http://www.docker.io/gettingstarted/), clone this repo somewhere, and then run:
 
 ```
-# docker build -rm -t <yourname>/wordpress .
+# docker build --rm -t <yourname>/wordpress .
 ```
 
 Or, alternately, build DIRECTLY from the github repo:
 
 ```
-# docker build -rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
+# docker build --rm -t <username>/wordpress git://github.com/scollier/dockerfiles-fedora-wordpress.git
 ```
 
 Run it:


### PR DESCRIPTION
Just cleaning up old Docker syntax.
