### PR TITLE
MariaDB: Improve README.md

### DIFF
--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -3,7 +3,10 @@ dockerfiles-sct-mariadb
 
 Based on scollier's mysql dockerfile.
 
-This repo contains a recipe for making Docker container for mariadb on Fedora. 
+This repo contains a recipe for making Docker container for mariadb on Fedora.
+
+Setup
+-----
 
 Check your Docker version
 
@@ -17,23 +20,14 @@ Check the image out.
 
     # docker images
 
-Run it:
+Launching MariaDB
+-----------------
+
+### Quick start (not recommended for production use): ###
 
     # docker run --name=mariadb -d -p 3306:3306 <yourname>/mariadb
 
-Keep in mind the initial password set for mariadb is: mysqlPassword.  Change it now:
-
-    # mysqladmin -u testdb -pmysqlPassword password myNewPass
-
-For mariadb:
-    # mysql -utestdb -pmyNewPass
-
-Create a table:
-
-    \> CREATE TABLE test (name VARCHAR(10), owner VARCHAR(10),
-        -> species VARCHAR(10), birth DATE, death DATE);
-
-
+### Recommended start ###
 To use a separate data volume for /var/lib/mysql (recommended, to allow image update without
 losing database contents):
 
@@ -42,7 +36,7 @@ Create a data volume container: (it doesn't matter what image you use
 here, we'll never run this container again; it's just here to
 reference the data volume)
 
-    # docker run --name=mariadb-data -v /var/lib/mysql fedora true
+    # docker run --name=mariadb-data -v /var/lib/mysql <yourname>/mariadb true
 
 Initialise it using a temporary one-time mariadb container:
 
@@ -51,3 +45,19 @@ Initialise it using a temporary one-time mariadb container:
 And now create the new persistent mariadb container:
 
     # docker run --name=mariadb -d -p 3306:3306 --volumes-from=mariadb-data <yourname>/mariadb
+
+Using your MariaDB container
+----------------------------
+
+Keep in mind the initial password set for mariadb is: mysqlPassword.  Change it now:
+
+    # mysqladmin --protocol=tcp -u testdb -pmysqlPassword password myNewPass
+
+Connecting to mariadb:
+
+    # mysql --protocol=tcp -utestdb -pmyNewPass
+
+Create a sample table:
+
+    \> CREATE TABLE test (name VARCHAR(10), owner VARCHAR(10),
+        -> species VARCHAR(10), birth DATE, death DATE);


### PR DESCRIPTION
Reorders some of the content to make the production vs. quickstart
more obvious.

Recommend the use of <yourname>/mariadb for the creation of the
data volume so as not to force the user to pull down the 'fedora'
image if they don't already have it.

Add --protocol=tcp to the mysqladmin and mysql commands, as
otherwise they will attempt to talk to the local socket which is
not connected to the container.
