### PR TITLE
Fix start-cups.sh by installing passwd

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 MAINTAINER "Tim Waugh" <twaugh@redhat.com>
 
 RUN yum -y update && yum clean all
-RUN yum -y install cups openssl && yum clean all
+RUN yum -y install cups openssl passwd && yum clean all
 ADD adjust-config.sh /adjust-config.sh
 ADD start-cups.sh /start-cups.sh
 RUN chmod 755 /adjust-config.sh /start-cups.sh


### PR DESCRIPTION
CUPS container would not start because start-cups.sh uses `passwd` which is not installed.