### PR TITLE
CUPS: Add printer based on environment variables

### DIFF
--- a/cups/README.md
+++ b/cups/README.md
@@ -79,3 +79,23 @@ $ lpstat -s
 
 If you set client.conf up in this way, graphical applications will
 also use the CUPS server in the container when printing.
+
+### Automating printer setup
+
+You can set up a printer through the web interface or by passing additional environment variables to docker (usefull for automation):
+
+```
+# docker run -d -e CUPS_PRINTER_NAME=<printer> -e CUPS_PRINTER_DRIVER=<driver> -e CUPS_PRINTER_CONNECTION=<uri> <username>/cups
+```
+
+See the man page of `lpadmin` for a detailed description of each option.
+
+* `CUPS_PRINTER_NAME` - The unique name for the new printer. Must not contain spaces. `lpadmin` `destination`.
+* `CUPS_PRINTER_DRIVER` - The System V interface script or PPD file for the printer. `lpadmin` option `-m`. 
+* `CUPS_PRINTER_CONNECTION` - The device-uri attribute for the printer. `lpadmin` option `-v`.
+
+To setup a Zebra label printer with a static IP address you could do:
+
+```
+# docker run -d -e CUPS_PRINTER_NAME=GX420t -e CUPS_PRINTER_DRIVER=drv:///sample.drv/zebraep2.ppd -e CUPS_PRINTER_CONNECTION=socket://192.168.1.42 <username>/cups
+```

--- a/cups/README.md
+++ b/cups/README.md
@@ -85,7 +85,7 @@ also use the CUPS server in the container when printing.
 You can set up a printer through the web interface or by passing additional environment variables to docker (usefull for automation):
 
 ```
-# docker run -d 
+# docker run -d \
     -e CUPS_PRINTER_NAME=<printer> \
     -e CUPS_PRINTER_DRIVER=<driver> \
     -e CUPS_PRINTER_CONNECTION=<uri> \
@@ -101,7 +101,7 @@ See the man page of `lpadmin` for a detailed description of each option.
 To setup a Zebra label printer with a static IP address you could do:
 
 ```
-# docker run -d 
+# docker run -d \
     -e CUPS_PRINTER_NAME=GX420t \
     -e CUPS_PRINTER_DRIVER=drv:///sample.drv/zebraep2.ppd \
     -e CUPS_PRINTER_CONNECTION=socket://192.168.1.42 \

--- a/cups/README.md
+++ b/cups/README.md
@@ -85,7 +85,11 @@ also use the CUPS server in the container when printing.
 You can set up a printer through the web interface or by passing additional environment variables to docker (usefull for automation):
 
 ```
-# docker run -d -e CUPS_PRINTER_NAME=<printer> -e CUPS_PRINTER_DRIVER=<driver> -e CUPS_PRINTER_CONNECTION=<uri> <username>/cups
+# docker run -d 
+    -e CUPS_PRINTER_NAME=<printer> \
+    -e CUPS_PRINTER_DRIVER=<driver> \
+    -e CUPS_PRINTER_CONNECTION=<uri> \
+    <username>/cups
 ```
 
 See the man page of `lpadmin` for a detailed description of each option.
@@ -97,5 +101,9 @@ See the man page of `lpadmin` for a detailed description of each option.
 To setup a Zebra label printer with a static IP address you could do:
 
 ```
-# docker run -d -e CUPS_PRINTER_NAME=GX420t -e CUPS_PRINTER_DRIVER=drv:///sample.drv/zebraep2.ppd -e CUPS_PRINTER_CONNECTION=socket://192.168.1.42 <username>/cups
+# docker run -d 
+    -e CUPS_PRINTER_NAME=GX420t \
+    -e CUPS_PRINTER_DRIVER=drv:///sample.drv/zebraep2.ppd \
+    -e CUPS_PRINTER_CONNECTION=socket://192.168.1.42 \
+    <username>/cups
 ```

--- a/cups/start-cups.sh
+++ b/cups/start-cups.sh
@@ -6,4 +6,15 @@ if ! grep -q "^$CUPS_ADMIN_USER:" /etc/shadow; then
 		(passwd --stdin "$CUPS_ADMIN_USER")
 fi
 
+if [ -n "$CUPS_PRINTER_NAME" ]; then
+	/usr/sbin/cupsd
+
+	echo Adding printer $CUPS_PRINTER_NAME:
+	echo "  Driver: $CUPS_PRINTER_DRIVER"
+	echo "  Connection: $CUPS_PRINTER_CONNECTION"
+	lpadmin -p $CUPS_PRINTER_NAME -E -m $CUPS_PRINTER_DRIVER -v $CUPS_PRINTER_CONNECTION
+
+	kill $(ps -eo comm,pid | grep cupsd | awk '{ print $2 }')
+fi
+
 exec /usr/sbin/cupsd -f


### PR DESCRIPTION
Motivated by my recently merged pull request I dare to request another one.

This one adds a printer based on the environment variables CUPS_PRINTER_NAME, CUPS_PRINTER_DRIVER, and CUPS_PRINTER_CONNECTION.

Use case: You want to quickly set up a known printer in an automated environment without the need to log into the web interface (which would certainly break automation).

I am not sure if this kind of change fits the philosophy of the project, but if so I would happily extend the README. Please let me know what you think.