### PR TITLE
Cups volumes

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -7,7 +7,6 @@ ADD adjust-config.sh /adjust-config.sh
 ADD start-cups.sh /start-cups.sh
 RUN chmod 755 /adjust-config.sh /start-cups.sh
 RUN /adjust-config.sh
-RUN printf "ServerAlias localhost\n" >> /etc/cups/cupsd.conf
 
 EXPOSE 631
 

--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -8,6 +8,7 @@ ADD start-cups.sh /start-cups.sh
 RUN chmod 755 /adjust-config.sh /start-cups.sh
 RUN /adjust-config.sh
 
+VOLUME ["/var/spool/cups", "/var/log/cups"]
 EXPOSE 631
 
 CMD ["/start-cups.sh"]

--- a/cups/README.md
+++ b/cups/README.md
@@ -107,3 +107,10 @@ To setup a Zebra label printer with a static IP address you could do:
     -e CUPS_PRINTER_CONNECTION=socket://192.168.1.42 \
     <username>/cups
 ```
+
+### Volumes
+
+The volumes defined by this container are:
+
+- /var/spool/cups (the spool directory)
+- /var/log/cups (for logs)

--- a/cups/adjust-config.sh
+++ b/cups/adjust-config.sh
@@ -24,3 +24,6 @@ sed -i \
 sed -i \
 	-e "s,^Browsing.*,Browsing Off," \
 	/etc/cups/cupsd.conf
+
+# Allow host<->container proxying
+printf "ServerAlias localhost\n" >> /etc/cups/cupsd.conf

--- a/cups/adjust-config.sh
+++ b/cups/adjust-config.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Listen for network connections.
+# Listen for network connections
 sed -i \
 	-e "0,/^Listen /{s,^Listen .*$,Port 631,}" \
 	-e "/^Listen /d" \
 	/etc/cups/cupsd.conf
 
-# Allow remote connections.
+# Allow remote connections
 sed -i \
 	-e "/<Location \/>/,/<\/Location>/{/<\/Location>/i\ \ Allow @LOCAL
 }" \
@@ -20,7 +20,7 @@ sed -i \
 }" \
 	/etc/cups/cupsd.conf
 
-# Disable browsing.
+# Disable browsing
 sed -i \
 	-e "s,^Browsing.*,Browsing Off," \
 	/etc/cups/cupsd.conf

--- a/cups/adjust-config.sh
+++ b/cups/adjust-config.sh
@@ -27,3 +27,8 @@ sed -i \
 
 # Allow host<->container proxying
 printf "ServerAlias localhost\n" >> /etc/cups/cupsd.conf
+
+# Log to file, not to journal
+sed -i \
+	-e "s,^ErrorLog .*,ErrorLog /var/log/cups/error_log," \
+	/etc/cups/cups-files.conf

--- a/cups/start-cups.sh
+++ b/cups/start-cups.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [ -z "$CUPS_ADMIN_USER" ]; then
+	printf "No CUPS_ADMIN_USER environment variable set.\n"
+	exit 1
+fi
+
 if ! grep -q "^$CUPS_ADMIN_USER:" /etc/shadow; then
 	echo Adding "$CUPS_ADMIN_USER" user
 	useradd "$CUPS_ADMIN_USER" --system -G root,sys -M


### PR DESCRIPTION
The cups container didn't define any volumes. Here is an update to fix that. It defines:

- /var/spool/cups (the spool directory)
- /var/log/cups (for logs)