### PR TITLE
dhcpd: install additional depencies

### DIFF
--- a/dhcpd/Dockerfile
+++ b/dhcpd/Dockerfile
@@ -3,9 +3,17 @@ FROM fedora
 
 MAINTAINER "Jiri Popelka" <jpopelka@redhat.com>
 
-# install main packages:
 RUN yum -y update && yum clean all
-RUN yum -y install dhcp && yum clean all
+
+# Package with dhcpd is called dhcp up to f21 and dhcp-server since f22.
+# We try to install both dhcp and dhcp-server packages, so it works with all
+# Fedora releases. If one of the packages doesn't exist (for example
+# dhcp-server on F21) yum tells you that 'No package dhcp-server available.',
+# but still installs the other one and everything's OK.
+# Even on F22 dhcp-compat provides dhcp, this will possibly be removed
+# in future, so we explicitly install also dhcp-server package.
+# ip & ipcalc are needed in dhcpd.sh
+RUN yum -y install dhcp dhcp-server /usr/sbin/ip /usr/bin/ipcalc && yum clean all
 
 ADD dhcpd.sh /dhcpd
 


### PR DESCRIPTION
This change pulls in additional dependencies, i.e.
dhcp-server: dhcp package has been renamed to dhcp-server since f22
ip & ipcalc: these are needed in dhcpd.sh