### PR TITLE
Fix #65 "passwd: command not found"

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 MAINTAINER scollier <scollier@redhat.com>
 
 RUN yum -y update && yum clean all
-RUN yum -y install openssh-server && yum clean all
+RUN yum -y install openssh-server passwd && yum clean all
 ADD ./start.sh /start.sh
 RUN mkdir /var/run/sshd
 


### PR DESCRIPTION
I reproduced the issue and tested the fix on Fedora 21.

This also fixes the 2nd issue reported on #66.