### PR TITLE
firefox: Fix #60 (container no workie) and refactor to use TigerVNC only

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -3,8 +3,7 @@ MAINTAINER scollier <emailscottcollier@gmail.com>
 
 # Install the appropriate software
 RUN yum -y update && yum clean all
-RUN yum -y install x11vnc \
-firefox xorg-x11-server-Xvfb \
+RUN yum -y install firefox \
 xorg-x11-twm tigervnc-server \
 xterm xorg-x11-font \
 xulrunner-26.0-2.fc20.x86_64 \
@@ -12,13 +11,13 @@ dejavu-sans-fonts \
 dejavu-serif-fonts \
 xdotool && yum clean all
 
-# Add the xstartup file into the image
-ADD ./xstartup /
+# Add the xstartup file into the image and set the default password.
+RUN mkdir /root/.vnc
+ADD ./xstartup /root/.vnc/
+RUN chmod -v +x /root/.vnc/xstartup
+RUN echo 123456 | vncpasswd -f > /root/.vnc/passwd
+RUN chmod -v 600 /root/.vnc/passwd
 
-RUN mkdir /.vnc
-RUN x11vnc -storepasswd 123456 /.vnc/passwd
-RUN  \cp -f ./xstartup /.vnc/.
-RUN chmod -v +x /.vnc/xstartup
 RUN sed -i '/\/etc\/X11\/xinit\/xinitrc-common/a [ -x /usr/bin/firefox ] && /usr/bin/firefox &' /etc/X11/xinit/xinitrc
 
 EXPOSE 5901


### PR DESCRIPTION
I tested this fix on Fedora 21.

I think the problem was that the classic VNC password file was being stored at `/.vnc/passwd`. On Fedora 21 at least, root's home dir is `/root/`. so it needed to be stored at `/root/.vnc/passwd`.

Also, installing both TigerVNC and x11vnc/Xvfb is redundant. Since TigerVNC `vncserver` is the CMD, I removed the x11vnc/Xvfb code. The `vncpasswd` command is part of TigerVNC.