### PR TITLE
simplify the virsh container

### DIFF
--- a/libvirt/virsh/Dockerfile
+++ b/libvirt/virsh/Dockerfile
@@ -1,16 +1,8 @@
-FROM fedora:20
-MAINTAINER "Brent Baude" <bbaude@redhat.com>
-ENV container docker
-RUN yum -y update && yum clean all
-RUN yum -y install virt-install systemd libvirt-client && yum clean all; \
-(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
-rm -f /etc/systemd/system/*.wants/*;\
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*;\
-rm -f /lib/systemd/system/anaconda.target.wants/*
+FROM fedora:rawhide
+MAINTAINER Lars Kellogg-Stedman <lars@redhat.com>
 
-VOLUME [ "/sys/fs/cgroup" ]
-CMD ["/usr/sbin/init"]
+RUN yum -y install \
+	virt-install \
+	libvirt-client \
+	; yum clean all
+


### PR DESCRIPTION
There was no reason for the virsh container to be running systemd, since
it runs no persistent services.  This changes also sets up a default
value for LIBVIRT_DEFAULT_URI that should make it easier to use in
common environments.