### PR TITLE
Updates to  owncloud to use Fedora:21.

### DIFF
--- a/owncloud/Dockerfile
+++ b/owncloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM       fedora:20
+FROM       fedora:21
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 # Perform updates
@@ -9,11 +9,10 @@ RUN yum install -y owncloud{,-httpd,-sqlite} && yum clean all
 
 # Install SSL module and force SSL to be used by owncloud
 RUN yum install -y mod_ssl && yum clean all
-RUN sed -i 's/"forcessl" => false,/"forcessl" => true,/' /etc/owncloud/config.php
+ADD ./forcessl.config.php /etc/owncloud/forcessl.config.php
 
 # Allow connections from everywhere
-RUN sed -i 's/Require local/Require all granted/' /etc/httpd/conf.d/owncloud.conf
-RUN sed -i "s/'trusted_domains'/#'trusted_domains'/" /etc/owncloud/config.php
+RUN ln -s /etc/httpd/conf.d/owncloud-access.conf.avail /etc/httpd/conf.d/z-owncloud-access.conf
 
 # Expose port 443 and set httpd as our entrypoint
 EXPOSE 443

--- a/owncloud/README.md
+++ b/owncloud/README.md
@@ -3,7 +3,8 @@ dockerfiles-fedora-OwnCloud
 
 This repo contains a recipe for making Docker container for OwnCloud on Fedora. 
 The docker file chooses httpd and sqlite for owncloud. These can easily be changed
-by changing what rpms get installed. This has been tested with docker 1.1.2 
+by changing what rpms get installed. This has been tested with docker 1.6.0 and 
+owncloud-7.0.5.
 
 Check your Docker version
 
@@ -22,7 +23,4 @@ Run it:
     # docker run -d -p 443:443 <yourname>/owncloud
 
 You should now be able to view the OwnCloud setup page by going to https://localhost/owncloud
-
-NOTE: Ignore the warning about webdav not being set up properly. This is because the SSL 
-      certificates aren't set up properly.
 

--- a/owncloud/forcessl.config.php
+++ b/owncloud/forcessl.config.php
@@ -1,0 +1,4 @@
+<?php
+$CONFIG = array (
+  'forcessl' => true,
+);


### PR DESCRIPTION

Updated the container to Fedora:21 and updated Dockerfile with changes
to configure the new owncloud in Fedora 21 (currently owncloud-7.0.5).