### PR TITLE
do not use apachectl to start in foreground

### DIFF
--- a/apache/run-apache.sh
+++ b/apache/run-apache.sh
@@ -5,4 +5,4 @@
 # if it thinks it is already running.
 rm -rf /run/httpd/* /tmp/httpd*
 
-exec /usr/sbin/apachectl -D FOREGROUND
+exec /usr/sbin/httpd -D FOREGROUND


### PR DESCRIPTION
fixes this error message:
$ docker run -it fedora/apache
Passing arguments to httpd using apachectl is no longer supported.
You can only start/stop/restart httpd using this script.
If you want to pass extra arguments to httpd, edit the
/etc/sysconfig/httpd config file.
AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.142. Set the 'ServerName' directive globally to suppress this message

