### PR TITLE
New Dockerfile for kea - DHCPv4, DHCPv6 and Dynamic DNS servers.

### DIFF
--- a/kea/Dockerfile
+++ b/kea/Dockerfile
@@ -1,18 +1,17 @@
 FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
-RUN dnf -y update; dnf -y install kea iproute; dnf clean all
-COPY ./adjust-config.sh /
-COPY ./start-kea.sh /
-RUN chmod -v +x /adjust-config.sh /start-kea.sh
-RUN /adjust-config.sh
+RUN dnf -y update && dnf -y install kea iproute && dnf clean all
+COPY adjust-config.sh start-kea.sh /usr/sbin/
+RUN chmod -v +x /usr/sbin/adjust-config.sh /usr/sbin/start-kea.sh
+RUN /usr/sbin/adjust-config.sh
 
 # dhcp4
 EXPOSE 67/udp
 # dhcp6
 EXPOSE 547/udp
 
-ENTRYPOINT ["/start-kea.sh"]
+ENTRYPOINT ["/usr/sbin/start-kea.sh"]
 
 # run dhcpv4 server by default
 # options are:

--- a/kea/Dockerfile
+++ b/kea/Dockerfile
@@ -1,0 +1,23 @@
+FROM fedora
+MAINTAINER http://fedoraproject.org/wiki/Cloud
+
+RUN dnf -y update; dnf -y install kea iproute; dnf clean all
+COPY ./adjust-config.sh /
+COPY ./start-kea.sh /
+RUN chmod -v +x /adjust-config.sh /start-kea.sh
+RUN /adjust-config.sh
+
+# dhcp4
+EXPOSE 67/udp
+# dhcp6
+EXPOSE 547/udp
+
+ENTRYPOINT ["/start-kea.sh"]
+
+# run dhcpv4 server by default
+# options are:
+# dhcp4: dhcpv4 server
+# dhcp6: dhcpv6 server
+# ddns: dhcp-ddns server
+# <others>: run arbitrary command (with args), like e.g. 'ls -la /var/lib/kea'
+CMD ["dhcp4"]

--- a/kea/README.md
+++ b/kea/README.md
@@ -1,0 +1,30 @@
+dockerfiles-fedora-kea
+=========================
+
+Fedora dockerfile for kea - DHCPv4, DHCPv6 and Dynamic DNS servers.
+Tested on Docker 1.6.2
+
+Clone Dockerfile somewhere and build the container:
+
+    # docker build --rm -t <username>/kea .
+
+Create a volume containers for configuration file and leases database:
+
+    # docker run -d -v /etc/kea --name kea-conf <username>/kea true
+    # docker run -d -v /var/lib/kea --name kea-db <username>/kea true
+
+Use a temporary container to edit the ``/etc/kea/kea.conf``:
+
+    # docker run --rm -it --volumes-from kea-conf <username>/kea vi /etc/kea/kea.conf
+
+Run named container (for DHCPv4):
+
+    # docker run -d -p 67:67/udp --volumes-from kea-conf --volumes-from kea-db --name kea4 <username>/kea
+
+Or DHCPv6:
+
+    # docker run -d -p 547:547/udp --volumes-from kea-conf --volumes-from kea-db --name kea6 <username>/kea dhcp6
+
+Or DHCP-DDNS:
+
+    # docker run -d --volumes-from kea-conf --name kea-ddns <username>/kea ddns

--- a/kea/README.md
+++ b/kea/README.md
@@ -2,7 +2,7 @@ dockerfiles-fedora-kea
 =========================
 
 Fedora dockerfile for kea - DHCPv4, DHCPv6 and Dynamic DNS servers.
-Tested on Docker 1.6.2
+Tested on Docker 1.8.2
 
 Clone Dockerfile somewhere and build the container:
 

--- a/kea/TEST.md
+++ b/kea/TEST.md
@@ -1,0 +1,65 @@
+Tested on Docker 1.8.2
+
+Run dhclient in a container and verify that it doesn't get any response for now:
+
+    # docker run --rm -it fedora sh -c 'dnf -y install dhcp-client && dhclient -d eth0'
+    DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval x
+    DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval xx
+    DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval xx
+    etc.
+
+press Ctrl+c
+
+Build the kea image if you haven't already:
+
+    # docker build --rm -t <username>/kea .
+
+Create a volume containers for configuration file and leases database:
+
+    # docker run -d -v /etc/kea --name kea-conf <username>/kea true
+    # docker run -d -v /var/lib/kea --name kea-db <username>/kea true
+
+Use a temporary container to edit the ``/etc/kea/kea.conf``:
+
+    # docker run --rm -it --volumes-from kea-conf <username>/kea vi /etc/kea/kea.conf
+
+change
+
+    "subnet4": [
+    #  {    "subnet": "192.0.2.0/24",
+    #       "pools": [ { "pool": "192.0.2.1 - 192.0.2.200" } ] }
+    ]
+
+to
+
+    "subnet4": [
+    {    "subnet": "172.17.0.0/16",
+         "pools": [ { "pool": "172.17.0.100 - 172.17.0.200" } ] }
+    ]
+
+Where 172.17.0.0/16 should be the subnet the containers' interfaces are in.
+You can verify it with
+
+    # docker run --rm -it fedora sh -c 'dnf -y install iproute; ip -4 addr show eth0'
+
+Run kea (DHCPv4) in named container:
+
+    # docker run -d -p 67:67/udp --volumes-from kea-conf --volumes-from kea-db --name kea4 <username>/kea
+
+If you see error ... listen udp 0.0.0.0:67: bind: address already in use
+you have to kill dnsmasq (which has been run by libvirtd) and run the container again.
+
+    # killall dnsmasq
+
+Try the dhclient once more and you should see something like:
+
+    # docker run --rm -it fedora sh -c 'dnf -y install dhcp-client && dhclient -d eth0'
+    DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 4
+    DHCPREQUEST on eth0 to 255.255.255.255 port 67
+    DHCPOFFER from 172.17.0.xx
+    DHCPACK from 172.17.0.xx
+    bound to 172.17.0.100 -- renewal in x seconds.
+
+If you killed dnsmasq previously, you can restart libvirtd, which will spawn it.
+
+    # systemctl restart libvirtd

--- a/kea/adjust-config.sh
+++ b/kea/adjust-config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i \
+        -e 's,"interfaces": \[ \],"interfaces": \[ "eth0" \],' \
+        /etc/kea/kea.conf

--- a/kea/start-kea.sh
+++ b/kea/start-kea.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [[ "${1}" = "dhcp4" ]]; then
+
+  if [[ ! -f /var/lib/kea/kea-leases4.csv ]]; then
+        touch /var/lib/kea/kea-leases4.csv
+  fi
+
+  exec kea-dhcp4 -d -c /etc/kea/kea.conf
+
+elif [[ "${1}" = "dhcp6" ]]; then
+
+  if [[ ! -f /var/lib/kea/kea-leases6.csv ]]; then
+        touch /var/lib/kea/kea-leases6.csv
+  fi
+
+  exec kea-dhcp6 -d -c /etc/kea/kea.conf
+
+elif [[ "${1}" = "ddns" ]]; then
+
+  exec kea-dhcp-ddns -d -c /etc/kea/kea.conf
+
+else
+
+    exec "$@"
+
+fi
+
+


### PR DESCRIPTION
[kea](http://kea.isc.org) is new open source DHCPv4/DHCPv6 server being developed by ​[Internet Systems Consortium](http://isc.org). Version 1.0 is planned for end of this year, but Fedora has been shipping 0.9 for some time. For example Facebook already [uses](https://www.isc.org/blogs/how-facebook-is-using-kea-in-the-datacenter/) it.