### PR TITLE
Allow tuning memcached through environment variables

### DIFF
--- a/memcached/Dockerfile
+++ b/memcached/Dockerfile
@@ -3,7 +3,9 @@ MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN  yum -y update && yum clean all
 RUN yum -y install memcached && yum clean all
+ADD start_memcached.sh /start_memcached.sh
+RUN chmod 755 /start_memcached.sh
 
 EXPOSE  11211
 
-CMD  ["memcached", "-u", "daemon"]
+CMD  ["/start_memcached.sh"]

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -17,6 +17,14 @@ To run:
 
     # docker run -d -p 11211:11211 <username>/memcached
 
+To run with additional tuning values:
+    # docker run -d -p 11211:11211 \
+      [-e MEMCACHED_CACHE_SIZE=<size_in_MB>] \
+      [-e MEMCACHED_CONNECTIONS=<max_simultaneous_connections>] \
+      [-e MEMCACHED_THREADS=<max_concurrent_threads>] \
+      <username>/memcached \
+
+
 Test:
 
 ```

--- a/memcached/start_memcached.sh
+++ b/memcached/start_memcached.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MEMCACHED_ARGS=
+
+if [ -n "$MEMCACHED_CACHE_SIZE" ]; then
+    MEMCACHED_ARGS+=" -m $MEMCACHED_CACHE_SIZE"
+fi
+
+if [ -n "$MEMCACHED_CONNECTIONS" ]; then
+    MEMCACHED_ARGS+=" -c $MEMCACHED_CONNECTIONS"
+fi
+
+if [ -n "$MEMCACHED_THREADS" ]; then
+    MEMCACHED_ARGS+=" -t $MEMCACHED_THREADS"
+fi
+
+exec /usr/bin/memcached -u daemon $MEMCACHED_ARGS


### PR DESCRIPTION
In many cases, it is useful to be able to tweak some of the performance settings of memcached. This patch adds three environment variables to do that:

* MEMCACHED_CACHE_SIZE: Size in MiB of the available cache
* MEMCACHED_CONNECTIONS: The number of simultaneous connections that can be served
* MEMCACHED_THREADS: The number of threads processing connections