### PR TITLE
Disable dnf-makecache for systemd apache

### DIFF
--- a/systemd/apache/Dockerfile
+++ b/systemd/apache/Dockerfile
@@ -9,7 +9,7 @@ EXPOSE 80
 
 RUN echo "systemd httpd server" > /var/www/html/index.html
 
-RUN systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount systemd-logind.service getty.target console-getty.service
+RUN systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount systemd-logind.service getty.target console-getty.service dnf-makecache.service
 RUN cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/; sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
 
 VOLUME ["/run", "/tmp"]


### PR DESCRIPTION
Given that package installation is unlikely for runtime containers,
running a package cache builder in the background doesn't make sense.