### PR TITLE
update django image

### DIFF
--- a/Django/Dockerfile
+++ b/Django/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:20
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
-RUN yum -y update && yum clean all
-RUN yum -y install python-pip python-django git sqlite && yum clean all
+RUN dnf -y update && dnf clean all
+RUN dnf -y install python-pip python-django git sqlite python-psycopg2 && dnf clean all
 
 EXPOSE 8000
 


### PR DESCRIPTION
 * use latest fedora base image (20 is not even supported anymore)
 * use yum instead of dnf
 * install psycopg2 since it's very common to use postgresql together
   with django