### PR TITLE
mount sources in django container

### DIFF
--- a/Django/Dockerfile
+++ b/Django/Dockerfile
@@ -4,7 +4,11 @@ MAINTAINER http://fedoraproject.org/wiki/Cloud
 RUN dnf -y update && dnf clean all
 RUN dnf -y install python-pip python-django git sqlite python-psycopg2 && dnf clean all
 
+# create directory /code and mount sources there
+RUN mkdir /code
+WORKDIR /code
+VOLUME /code
+
 EXPOSE 8000
 
-CMD [ "/bin/bash" ]
-
+CMD python manage.py runserver 0.0.0.0:8000

--- a/Django/README.md
+++ b/Django/README.md
@@ -3,7 +3,7 @@ dockerfiles-fedora-django
 
 Fedora dockerfile for django
 
-Tested on Docker 1.0.0
+Tested on Docker 1.8.1
 
 To build:
 
@@ -15,6 +15,11 @@ Copy the sources down -
 To run:
 
     # docker run -d -p 8000:8000 <username>/django
+
+
+You can create project in current directory like this:
+
+    # docker run -v .:/code <username>/django django-admin startproject awesome_web .
 
 
 To test:


### PR DESCRIPTION
During writing `docker-compose` [content](https://github.com/developer-portal/content/pull/59) for fedora developer portal I realized I need to improve django image even further.

The thing is that I want to bindmount sources inside container so I don't have to rebuild it every time I change some code. I think it would make sense to have such change in upstream since the changes are not so disruptive.
