### PR TITLE
add fpaste

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y install \
            kernel \
            e2fsprogs \
            sos \
+           fpaste \
            crash \
            strace \
            ltrace \


### PR DESCRIPTION
Add fpaste — it's really useful for quick sharing of diagnostic information. See [Fedora Magazine article on fpaste](http://fedoramagazine.org/use-fpaste-share-problem-reports/)