### PR TITLE
README.md - fix link to Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ This is the upstream source for the [fedora-dockerfiles](http://koji.fedoraproje
 # sudo yum install docker-io fedora-dockerfiles
 ```
 
-Some [guidelines](https://github.com/scollier/Fedora-Dockerfiles/wiki/Guidelines-for-Creating-Dockerfiles) for contributing to this repo.
+Some [guidelines](https://github.com/fedora-cloud/Fedora-Dockerfiles/wiki/Guidelines-for-Creating-Dockerfiles) for contributing to this repo.
 
 We welcome contributions.


### PR DESCRIPTION
Fix the link to "Guidelines for Creating Dockerfiles".

This probably applies to all branches.  Particularly fixing master would be nice, for people looking at this on Github.