### PR TITLE
[FIX] firefox Dockerfile works with fedora 23 now

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,15 +1,10 @@
-FROM fedora
+FROM fedora:23
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 # Install the appropriate software
-RUN yum -y update && yum clean all
-RUN yum -y install firefox \
-xorg-x11-twm tigervnc-server \
-xterm xorg-x11-font \
-xulrunner-26.0-2.fc20.x86_64 \
-dejavu-sans-fonts \
-dejavu-serif-fonts \
-xdotool && yum clean all
+RUN dnf -y update
+RUN dnf -y install firefox xorg-x11-twm tigervnc-server xterm xulrunner dejavu-sans-fonts dejavu-serif-fonts xdotool
+RUN dnf clean all
 
 # Add the xstartup file into the image and set the default password.
 RUN mkdir /root/.vnc


### PR DESCRIPTION
I have tried to build firefox docker image on Fedora 23 linux and it failed, because the package
`xorg-x11-font` is not existent.

```shell
[root@vodolaz095 firefox]# docker build .
Sending build context to Docker daemon 4.096 kB
Step 0 : FROM fedora:23
 ---> 0721f2b3cb16
Step 1 : MAINTAINER http://fedoraproject.org/wiki/Cloud
 ---> Using cache
 ---> f32adaeb4a49
Step 2 : RUN dnf -y update && yum clean all
 ---> Running in 0131a92314dc
Last metadata expiration check performed 0:00:18 ago on Sat Jan  9 08:02:08 2016.
Dependencies resolved.
================================================================================
 Package             Arch          Version                 Repository      Size
================================================================================
Installing:
 libsecret           x86_64        0.18.3-1.fc23           fedora         156 k
Upgrading:
 file-libs           x86_64        5.22-6.fc23             updates        423 k
 glibc               x86_64        2.22-7.fc23             updates        3.6 M
 glibc-common        x86_64        2.22-7.fc23             updates         11 M
 grep                x86_64        2.22-5.fc23             updates        275 k
 libnghttp2          x86_64        1.6.0-1.fc23            updates         65 k
 pinentry            x86_64        0.9.6-4.fc23            updates         81 k
 systemd             x86_64        222-11.fc23             updates        6.3 M
 systemd-libs        x86_64        222-11.fc23             updates        473 k

Transaction Summary
================================================================================
Install  1 Package
Upgrade  8 Packages

Total download size: 23 M
Downloading Packages:
/usr/share/doc/grep/AUTHORS: No such file or directory
cannot reconstruct rpm from disk files
/usr/share/doc/file-libs/ChangeLog: No such file or directory
cannot reconstruct rpm from disk files
/usr/share/man/man8/udevadm.8.gz: No such file or directory
cannot reconstruct rpm from disk files
/usr/share/doc/glibc/BUGS: No such file or directory
cannot reconstruct rpm from disk files
file-libs-5.22-6.fc23.x86_64: Delta RPM rebuild failed
grep-2.22-5.fc23.x86_64: Delta RPM rebuild failed
systemd-222-11.fc23.x86_64: Delta RPM rebuild failed
glibc-2.22-7.fc23.x86_64: Delta RPM rebuild failed
--------------------------------------------------------------------------------
Total                                           3.8 MB/s |  25 MB     00:06     
Delta RPMs reduced 22.7 MB of updates to 25.1 MB (-10.1% saved)
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Upgrading   : glibc-common-2.22-7.fc23.x86_64                            1/17 
  Upgrading   : glibc-2.22-7.fc23.x86_64                                   2/17 
  Installing  : libsecret-0.18.3-1.fc23.x86_64                             3/17 
  Upgrading   : grep-2.22-5.fc23.x86_64                                    4/17 
  Upgrading   : systemd-libs-222-11.fc23.x86_64                            5/17 
  Upgrading   : systemd-222-11.fc23.x86_64                                 6/17 
  Upgrading   : pinentry-0.9.6-4.fc23.x86_64                               7/17 
  Upgrading   : file-libs-5.22-6.fc23.x86_64                               8/17 
  Upgrading   : libnghttp2-1.6.0-1.fc23.x86_64                             9/17 
  Cleanup     : systemd-222-10.fc23.x86_64                                10/17 
  Cleanup     : grep-2.22-3.fc23.x86_64                                   11/17 
  Cleanup     : systemd-libs-222-10.fc23.x86_64                           12/17 
  Cleanup     : pinentry-0.9.6-3.fc23.x86_64                              13/17 
  Cleanup     : libnghttp2-1.3.3-1.fc23.x86_64                            14/17 
  Cleanup     : file-libs-5.22-5.fc23.x86_64                              15/17 
  Cleanup     : glibc-common-2.22-6.fc23.x86_64                           16/17 
  Cleanup     : glibc-2.22-6.fc23.x86_64                                  17/17 
  Verifying   : libsecret-0.18.3-1.fc23.x86_64                             1/17 
  Verifying   : file-libs-5.22-6.fc23.x86_64                               2/17 
  Verifying   : glibc-2.22-7.fc23.x86_64                                   3/17 
  Verifying   : glibc-common-2.22-7.fc23.x86_64                            4/17 
  Verifying   : grep-2.22-5.fc23.x86_64                                    5/17 
  Verifying   : libnghttp2-1.6.0-1.fc23.x86_64                             6/17 
  Verifying   : pinentry-0.9.6-4.fc23.x86_64                               7/17 
  Verifying   : systemd-222-11.fc23.x86_64                                 8/17 
  Verifying   : systemd-libs-222-11.fc23.x86_64                            9/17 
  Verifying   : file-libs-5.22-5.fc23.x86_64                              10/17 
  Verifying   : systemd-222-10.fc23.x86_64                                11/17 
  Verifying   : systemd-libs-222-10.fc23.x86_64                           12/17 
  Verifying   : glibc-2.22-6.fc23.x86_64                                  13/17 
  Verifying   : glibc-common-2.22-6.fc23.x86_64                           14/17 
  Verifying   : pinentry-0.9.6-3.fc23.x86_64                              15/17 
  Verifying   : grep-2.22-3.fc23.x86_64                                   16/17 
  Verifying   : libnghttp2-1.3.3-1.fc23.x86_64                            17/17 

Installed:
  libsecret.x86_64 0.18.3-1.fc23                                                

Upgraded:
  file-libs.x86_64 5.22-6.fc23           glibc.x86_64 2.22-7.fc23              
  glibc-common.x86_64 2.22-7.fc23        grep.x86_64 2.22-5.fc23               
  libnghttp2.x86_64 1.6.0-1.fc23         pinentry.x86_64 0.9.6-4.fc23          
  systemd.x86_64 222-11.fc23             systemd-libs.x86_64 222-11.fc23       

Complete!
Yum command has been deprecated, redirecting to '/usr/bin/dnf clean all'.
See 'man dnf' and 'man yum2dnf' for more information.
To transfer transaction metadata from yum to DNF, run:
'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'

Cleaning repos: fedora updates
Cleaning up Everything
 ---> 6c3e228626a4
Removing intermediate container 0131a92314dc
Step 3 : RUN dnf -y install firefox xorg-x11-twm tigervnc-server xterm xorg-x11-font xulrunner dejavu-sans-fonts dejavu-serif-fonts xdotool && dnf clean all
 ---> Running in cd9de510c0e7
Last metadata expiration check performed 0:00:06 ago on Sat Jan  9 08:03:35 2016.
No package xorg-x11-font available.
Error: Unable to find a match.
The command '/bin/sh -c dnf -y install firefox xorg-x11-twm tigervnc-server xterm xorg-x11-font xulrunner dejavu-sans-fonts dejavu-serif-fonts xdotool && dnf clean all' returned a non-zero code: 1

```

i have removed this package and used `dnf` instead of `yum` and it seems to work