### PR TITLE
Use the latest Fedora image.

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum clean all

--- a/cadvisor/Dockerfile
+++ b/cadvisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum clean all

--- a/cockpit-ws/Dockerfile
+++ b/cockpit-ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum install -y sed openssl && yum clean all

--- a/container-best-practices/Dockerfile
+++ b/container-best-practices/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora
 
 MAINTAINER Scott Collier <scollier@redhat.com>
 

--- a/couchdb/Dockerfile
+++ b/couchdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN  yum -y update && yum clean all

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:23
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 # Install the appropriate software

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum clean all

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 RUN yum -y update && yum clean all
 RUN yum -y install mariadb-server pwgen psmisc net-tools hostname && \

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum clean all

--- a/owncloud/Dockerfile
+++ b/owncloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM       fedora:21
+FROM       fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 # Perform updates

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-FROM index.docker.io/fedora:22
+FROM fedora
 MAINTAINER Pavel Raiskup <praiskup@redhat.com>
 
 ENV container="docker"

--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:20
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum update -y &&  yum clean all

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:22
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 ENV container docker


### PR DESCRIPTION
In master, we probably should build with whatever the latest images are -- either fedora:rawhide, or fedora(:latest).

I did not change pdftk/Dockerfile because pdftk is not in Fedora 23 -- not sure if we want to keep the Dockerfile around when it (likely) won't build on Fedora 23.