### PR TITLE
Improve docker example for nodejs

### DIFF
--- a/nodejs/.dockerignore
+++ b/nodejs/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,12 +1,10 @@
-FROM fedora:23
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 # Install nodejs and npm
-RUN dnf -y update
-RUN dnf -y install npm
-RUN dnf clean all
+RUN dnf -y update && dnf -y install npm && dnf clean all
 
-# Show nodejs versions
+# Show nodejs and npm versions installed
 RUN node -v
 RUN npm -v
 

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,13 +1,32 @@
-FROM fedora
+FROM fedora:23
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
-RUN yum -y update && yum clean all
-RUN yum -y install npm && yum clean all
+# Install nodejs and npm
+RUN dnf -y update
+RUN dnf -y install npm
+RUN dnf clean all
 
-ADD . /src
+# Show nodejs versions
+RUN node -v
+RUN npm -v
 
-RUN cd /src; npm install
-
+# Set port for nodejs to listen on and expose it
+ENV PORT 8080
 EXPOSE 8080
 
+# Set production environment for nodejs application
+ENV NODE_ENV=production
+
+# Make directory for our nodejs project
+RUN mkdir /src
+
+# Inject package.json into directory and install all dependencies required
+# to be cached in order of making future builds faster
+ADD package.json /src
+RUN cd /src; npm install
+
+# Add code of our nodejs project with respect to gitignore
+ADD . /src
+
+# Run it!
 CMD ["node", "/src/index.js"]

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -1,13 +1,17 @@
-var express = require('express');
+'use strict';
 
-// Constants
-var PORT = 8080;
+var
+  express = require('express'),
+  app = express(),
+  port = process.env.PORT || 3000; //load port number from application environment
 
-// App
-var app = express();
 app.get('/', function (req, res) {
-  res.send('Hello World\n');
+  res.send('Hello from Docker container!\n');
 });
 
-app.listen(PORT)
-console.log('Running on http://localhost:' + PORT);
+app.listen(port, function(error){
+  if(error) {
+    throw error; //error binding to port
+  }
+  console.log('ExpressJS application is running on http://localhost:%d', port);
+});

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,10 +1,13 @@
 {
   "name": "docker-fedora-hello",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Node.js Hello World app on Fedora using docker, created from the Node.js example on docker.io",
   "author": "Jason Clark <jclark@redhat.com>",
   "dependencies": {
-    "express": "3.x"
+    "express": "4.x"
+  },
+  "scripts":{
+    "start":"node index.js"
   }
 }


### PR DESCRIPTION
- Update nodejs Dockerfile to use `dnf` instead of `yum`. 
- Add caching of npm modules installed.
- Some small improvements on nodejs application example.