### PR TITLE
Fix #168 Apache Docker image works

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,14 +1,8 @@
-FROM fedora:23
+FROM fedora
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
-# Updating dependencies
-RUN dnf -y update
-
-# Installing Apache
-RUN dnf -y install httpd
-
-# Cleaning dnf caches to reduce container size
-RUN dnf clean all
+# Updating dependencies, installing Apache and cleaning dnf caches to reduce container size
+RUN dnf -y update && dnf -y install httpd && dnf clean all
 
 # Creating placeholder file to be served by apache
 RUN echo "Apache" >> /var/www/html/index.html

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,10 +1,19 @@
-FROM fedora
+FROM fedora:23
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 
-RUN yum -y update && yum clean all
-RUN yum -y install httpd && yum clean all
+# Updating dependencies
+RUN dnf -y update
+
+# Installing Apache
+RUN dnf -y install httpd
+
+# Cleaning dnf caches to reduce container size
+RUN dnf clean all
+
+# Creating placeholder file to be served by apache
 RUN echo "Apache" >> /var/www/html/index.html
 
+# We open 80 port, the default one for HTTP for Apache server to listen on
 EXPOSE 80
 
 # Simple startup script to avoid some issues observed with container restart 


### PR DESCRIPTION
Apache docker image now uses `Fedora:23` base image and `dnf` instead of `yum`. 
It can be build as intended on Docker version `1.8.2-fc22, build cb216be/1.8.2`