### PR TITLE
Use systemd.unit dependencies to start the container.

### DIFF
--- a/sssd/Dockerfile
+++ b/sssd/Dockerfile
@@ -23,7 +23,7 @@ ADD rhel-domainname.service /etc/systemd/system/fedora-domainname.service
 ADD sssd.service /etc/sssd.service.template
 
 LABEL INSTALL 'docker run --rm=true --privileged --net=host -v /:/host -e NAME=${NAME} -e IMAGE=${IMAGE} -e HOST=/host ${IMAGE} /bin/install.sh'
-LABEL RUN 'docker run -d --restart=always --security-opt label:type:sssd_t --privileged --net=host --name ${NAME} -e NAME=${NAME} -e IMAGE=${IMAGE} \
+LABEL RUN 'docker run -d --security-opt label:type:sssd_t --privileged --net=host --name ${NAME} -e NAME=${NAME} -e IMAGE=${IMAGE} \
 	-v /etc/ipa/:/etc/ipa/:ro \
 	-v /etc/krb5.conf:/etc/krb5.conf:ro \
 	-v /etc/krb5.keytab:/etc/krb5.keytab:ro \

--- a/sssd/sssd.service
+++ b/sssd/sssd.service
@@ -7,6 +7,9 @@
 [Unit]
 Description=System Security Services Daemon in container
 
+Requires=docker.service
+After=docker.service
+
 # SSSD will not be started until syslog is
 After=syslog.target
 # SSSD must be running before we permit user sessions
@@ -21,3 +24,4 @@ RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target
+WantedBy=docker.service


### PR DESCRIPTION
The --restart=always did not respect systemctl disable sssd so after
reboot the container was always running irrespective of admin's wishes.