### PR TITLE
On Fedora 23, dhcp-compat pulls in dhcp-relay which is not necessary for server.

### DIFF
--- a/dhcpd/Dockerfile
+++ b/dhcpd/Dockerfile
@@ -5,15 +5,7 @@ MAINTAINER http://fedoraproject.org/wiki/Cloud
 
 RUN yum -y update && yum clean all
 
-# Package with dhcpd is called dhcp up to f21 and dhcp-server since f22.
-# We try to install both dhcp and dhcp-server packages, so it works with all
-# Fedora releases. If one of the packages doesn't exist (for example
-# dhcp-server on F21) yum tells you that 'No package dhcp-server available.',
-# but still installs the other one and everything's OK.
-# Even on F22 dhcp-compat provides dhcp, this will possibly be removed
-# in future, so we explicitly install also dhcp-server package.
-# ip & ipcalc are needed in dhcpd.sh
-RUN yum -y install dhcp dhcp-server /usr/sbin/ip /usr/bin/ipcalc && yum clean all
+RUN yum -y install dhcp-server /usr/sbin/ip /usr/bin/ipcalc && yum clean all
 
 ADD dhcpd.sh /dhcpd
 


### PR DESCRIPTION
Maintaining backwards build compatibility is noble but we can use git branches for that.