### PR TITLE
Use latest Fedora image in master.

### DIFF
--- a/lighttpd/Dockerfile
+++ b/lighttpd/Dockerfile
@@ -1,5 +1,5 @@
 # Based on the Fedora image
-FROM docker.io/fedora:22
+FROM fedora
 
 MAINTAINER http://fedoraproject.org/wiki/Cloud
 


### PR DESCRIPTION
Reverting the FROM change caused by 0a9b9b6a90a10a6eebbaa6f8d3fd348cd3fbd633.