### PR TITLE
make sure that npm cli tools (grunt, bower, yo) end up in the $PATH

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -13,7 +13,8 @@ ENV PORT 8080
 EXPOSE 8080
 
 # Set production environment for nodejs application
-ENV NODE_ENV=production
+ENV NODE_ENV=production \
+    PATH=/src/node_modules/.bin/:$PATH
 
 # Make directory for our nodejs project
 RUN mkdir /src


### PR DESCRIPTION
This change should enable userspace installation of `grunt`, `gulp`, `bower`, `yo` and similar npm CLI tools through the `package.json` file.

These tools usually need to be installed using the `--global` flag, or `npm install -g`. This allows the tools to be installed through the standard `npm install` process (without requiring any userland code to be run as root).