### PR TITLE
Use the standard "npm start" hook to launch Node applications

### DIFF
--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -26,5 +26,5 @@ RUN cd /src; npm install
 # Add code of our nodejs project with respect to gitignore
 ADD . /src
 
-# Run it!
-CMD ["node", "/src/index.js"]
+# Run it! https://docs.npmjs.com/cli/start
+CMD ["npm", "start"]


### PR DESCRIPTION
NodeJS applications are usually initialized by running `npm start`

https://docs.npmjs.com/cli/start

This allows developers to specify their own custom init process using the `scripts.start` section of their included `package.json` file.

**WARNING:** For users who fail to include a package.json file, or who fail to define a valid `scripts.start` section: The new default server init file will now be changed to npm's fallback value of `server.js` (rather than `index.js`, which is default init file for npm module packages)