### PR TITLE
atomic_scan_openscap: Add new image for CVE scanning RHEL

### DIFF
--- a/atomic_scan_openscap/Dockerfile
+++ b/atomic_scan_openscap/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:23
+LABEL Component="openscap-daemon" \
+      Name="fedora-cloud/atomic-scan-openscap" \
+      Version="0.1" \
+      Release="0"
+
+ENV container docker
+RUN dnf -y install dnf-plugins-core &&  dnf config-manager --set-enabled updates-testing && \
+    dnf -y install \
+                openscap-containers \
+                openscap-daemon \
+                scap-security-guide \
+                wget && \
+    dnf clean all
+
+ADD install.sh /root/
+ADD run.sh /root/
+ADD atomic_scan_openscap /root/
+ADD config.ini /root
+
+LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
+
+LABEL RUN="docker run -it --rm -v /:/host/ IMAGE sh /root/run.sh"
+
+# Dockerfile reference discourages "ADD" with remote source
+# I would love to tag this with NOCACHE but Dockerfile doesn't have an
+# instruction for that. Instead the person building it has to use --no-cache
+
+RUN wget --no-verbose -P /var/lib/oscapd/cve_feeds/ \
+    https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2 && \
+    bzip2 -dk /var/lib/oscapd/cve_feeds/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2

--- a/atomic_scan_openscap/README.md
+++ b/atomic_scan_openscap/README.md
@@ -1,0 +1,42 @@
+# atomic_scan_openscap
+
+This image contains various pieces of the [openSCAP project](https://www.open-scap.org/) which when
+used with the [atomic command line application](https://github.com/projectatomic/atomic) can scan
+for vulnerabilities within a RHEL filesystem.  With the _atomic scan_ command, you can scan
+containers and images as well as any root filesystem mounted to your host.
+
+The atomic_scan_openscap image will not run stand-alone and must be run in conjunction with
+_atomic scan_.
+
+## Prerequisites
+
+You must have docker and atomic installed on your system.
+
+## Installation
+
+To check if the atomic_scan_openscap is already configured for your system, use _atomic scan --list_.
+If it is not configured, simply issue _atomic install docker.io/atomic_scan_openscap_.  This will pull
+the image from the registry and copy its configuration file to /etc/atomic.d/.
+
+A configuration file for the openscap-daemon is also placed in /etc/oscapd/.  This controls the
+way openscap-daemon runs.
+
+### Configuration
+
+If you wish to make _atomic_scan_openscap_ your default atomic scanner, edit _/etc/atomic.conf_ and
+alter the **default_scanner** value.
+
+By default, the atomic_scan_openscap image will not fetch new CVE definitions by default.  To alter
+this behavior, simply set **fetch-cve** to _yes_ in _/etc/oscapd/config.ini_.
+
+### Building
+
+docker build -t atomic_scan_openscap .
+
+## Running
+
+This image will only run in conjunction with atomic_scan.  
+
+## Usage
+
+_atomic scan --scanner docker.io/atomic_scan_openscap <image|container names>_

--- a/atomic_scan_openscap/atomic_scan_openscap
+++ b/atomic_scan_openscap/atomic_scan_openscap
@@ -1,0 +1,11 @@
+type: scanner
+scanner_name: atomic_scan_openscap
+image_name: docker.io/atomic_scan_openscap
+default_scan: cve
+custom_args: ['-v', '/etc/oscapd:/etc/oscapd:ro']
+scans: [ 
+      { name: cve,
+        args: ['oscapd-evaluate', 'scan',  '--no-standard-compliance', '--targets', 'chroots-in-dir:///scanin',  '--output', '/scanout'],
+        description: "Performs a CVE scan based on known CVE data"},
+]
+    

--- a/atomic_scan_openscap/config.ini
+++ b/atomic_scan_openscap/config.ini
@@ -1,0 +1,24 @@
+[General]
+tasks-dir = /var/lib/oscapd/tasks
+results-dir = /var/lib/oscapd/results
+work-in-progress-dir = /var/lib/oscapd/work_in_progress
+cve-feeds-dir = /var/lib/oscapd/cve_feeds
+jobs = 4
+
+[Tools]
+oscap = /usr/bin/oscap
+oscap-ssh = /usr/bin/oscap-ssh
+oscap-vm = /usr/bin/oscap-vm
+oscap-docker = /usr/bin/oscap-docker
+oscap-chroot = /usr/bin/oscap-chroot
+container-support = yes
+
+[Content]
+cpe-oval = /usr/share/openscap/cpe/openscap-cpe-oval.xml
+ssg = /usr/share/xml/scap/ssg/content
+
+[CVEScanner]
+fetch-cve = no
+fetch-cve-url = https://www.redhat.com/security/data/oval/
+fetch-cve-timeout = 600
+

--- a/atomic_scan_openscap/install.sh
+++ b/atomic_scan_openscap/install.sh
@@ -1,0 +1,37 @@
+#/bin/bash
+ETC='/etc/oscapd'
+ETC_FILE='config.ini'
+HOST='/host'
+
+
+echo ""
+echo "Installing the configuration file 'atomic_scan_openscap' into /etc/atomic.d/.  You can now use this scanner with atomic scan with the --scanner atomic_scan_openscap command-line option.  You can also set 'atomic_scan_openscap' as the default scanner in /etc/atomic.conf.  To list the scanners you have configured for your system, use 'atomic scan --list'."
+
+echo ""
+cp /root/atomic_scan_openscap /host/etc/atomic.d
+
+
+
+# Check if /etc/oscapd exists on the host
+if [[ ! -d ${HOST}/${ETC} ]]; then
+    mkdir ${HOST}/${ETC}
+fi
+
+DATE=$(date +'%Y-%m-%M-%T')
+
+# Check if /etc/oscapd/config.ini exists
+if [[ -f ${HOST}/${ETC}/${ETC_FILE} ]]; then
+    SAVE_NAME=${ETC_FILE}.${DATE}.atomic_save
+    echo "Saving current ${ETC_FILE} as ${SAVE_NAME}"
+    mv ${HOST}/${ETC}/${ETC_FILE} ${HOST}/${ETC}/${SAVE_NAME}
+fi
+
+# Add config.ini to the host filesystem
+echo "Updating ${ETC_FILE} with latest configuration"
+cp /root/config.ini ${HOST}/${ETC}
+
+# Exit Message
+echo "Installation complete. You can customize ${ETC}/${ETC_FILE} as needed."
+
+
+echo ""

--- a/atomic_scan_openscap/run.sh
+++ b/atomic_scan_openscap/run.sh
@@ -1,0 +1,13 @@
+#/bin/bash
+
+echo ""
+if [ ! -e /host/etc/atomic.d/atomic_scan_openscap ]; then
+    echo "No atomic_scan_openscap file found in /etc/atomic.d.  This image requires you install it with 'atomic install docker.io/atomic_scan_openscap'"
+
+else
+    echo "This container/image is not meant to be run outside of the atomic command. You can use this image by issuing 'atomic scan <container|image  to scanb'.  See 'atomic scan --help' for more information."
+
+fi
+
+echo ""
+


### PR DESCRIPTION
This image is based on openscap and openscap-daemon.  It is only designed
to work with the atomic cli. It will not run stand-alone.