### PR TITLE
Correct Image Name: docker.io/fedora/atomic_scan_openscap

### DIFF
--- a/atomic_scan_openscap/atomic_scan_openscap
+++ b/atomic_scan_openscap/atomic_scan_openscap
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: atomic_scan_openscap
-image_name: docker.io/atomic_scan_openscap
+image_name: docker.io/fedora/atomic_scan_openscap
 default_scan: cve
 custom_args: ['-v', '/etc/oscapd:/etc/oscapd:ro']
 scans: [ 


### PR DESCRIPTION
Small correction to correct the image name defined in the
scan configurationi file.