### PR TITLE
Remove vim-minimal

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -7,10 +7,11 @@ LABEL RUN="docker run -it --name NAME --privileged --ipc=host --net=host --pid=h
 RUN [ -e /etc/yum.conf ] && sed -i '/tsflags=nodocs/d' /etc/yum.conf || true
 
 # Reinstall all packages to get man pages for them
-RUN dnf -y reinstall "*" && dnf clean all
+RUN dnf -y update && dnf -y reinstall "*" && dnf clean all
 
 # Install all useful packages
-RUN dnf -y install \
+RUN dnf -y remove vim-minimal && \
+    dnf -y install \
            abrt \
            bash-completion \
            bc \


### PR DESCRIPTION
Because of a conflict between vim-enhanced and vim-minimal, we
need to remove vim-minimal from the base install in order for
this image to build correctly.